### PR TITLE
Upgrade to nom 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 
 [dependencies]
 libc = "*"
-nom = "*"
+nom = "~1.0.0"
 
 [lib]
 name = "csvparser"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,18 +1,7 @@
 use nom::{IResult, not_line_ending, line_ending};
 
 fn csv_line(input: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-	terminated!(input, separated_list!(filter!(apply!(check_characters, b"\n\r,")), not_line_ending), line_ending)
-}
-
-fn check_characters(data: &[u8], characters: &[u8]) -> bool {
-	for i in 0..data.len() {
-		for c in characters {
-			if data[i] == *c {
-				return false;
-			}
-		}
-	}
-	true
+	terminated!(input, separated_list!(is_not_bytes!(&b"\n\r,"[..]), not_line_ending), line_ending)
 }
 
 #[test]


### PR DESCRIPTION
Hi!

nom 1.0 is here, and comes with a few breaking changes. To help the transition, and to test the beta version before release, I took the liberty to test and upgrade (if needed) your code to the 1.0 version. It should work right away, but if there are still issues, or if the code needs to be updated to your latest master, please let me know!

If you want an explanation of the changes, please take a look at the [upgrading documentation](https://github.com/Geal/nom/wiki/Upgrading-to-nom-1.0).

By the way, could you go to one (or all) of those links and write a few kind words about your experience writing parsers in Rust? It would really help me!
- [nom 1.0 release blogpost](https://www.clever-cloud.com/blog/engineering/2015/11/16/nom-1-0/)
- [Reddit post](https://www.reddit.com/r/rust/comments/3t10f3/nom_just_reached_10_cleaner_parsers_more_generic/)
- [Hacker News post](https://news.ycombinator.com/item?id=10574828)

Thank you for using nom!
